### PR TITLE
feat(error): add busy error page and Jakarta EE migration

### DIFF
--- a/src/main/resources/view/error/busy.jsp
+++ b/src/main/resources/view/error/busy.jsp
@@ -1,0 +1,28 @@
+<%@page pageEncoding="UTF-8" contentType="text/html; charset=UTF-8"%><!DOCTYPE html>
+<html>
+<head profile="http://a9.com/-/spec/opensearch/1.1/">
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<title><la:message key="labels.busy_title" /></title>
+<link href="${fe:url('/css/simple/style.css')}" rel="stylesheet"
+	type="text/css" />
+</head>
+<body class="error">
+	<header>
+		<jsp:include page="../header.jsp" />
+	</header>
+	<main class="container">
+		<div class="text-center">
+			<h2>
+				<la:message key="labels.busy_title" />
+			</h2>
+			<div class="errormessage"><la:message key="labels.busy_message" /></div>
+		</div>
+	</main>
+	<jsp:include page="../footer.jsp" />
+	<input type="hidden" id="contextPath" value="<%=request.getContextPath()%>" />
+	<script type="text/javascript" src="${fe:url('/js/simple/suggestor.js')}"></script>
+	<script type="text/javascript" src="${fe:url('/js/simple/search.js')}"></script>
+</body>
+</html>

--- a/src/main/resources/view/error/redirect.jsp
+++ b/src/main/resources/view/error/redirect.jsp
@@ -1,10 +1,10 @@
-<% 
-Integer statusCode = (Integer)request.getAttribute("javax.servlet.error.status_code");
-String servletName = (String)request.getAttribute("javax.servlet.error.servlet_name");
-String requestUri = (String)request.getAttribute("javax.servlet.error.request_uri");
+<%
+Integer statusCode = (Integer)request.getAttribute("jakarta.servlet.error.status_code");
+String servletName = (String)request.getAttribute("jakarta.servlet.error.servlet_name");
+String requestUri = (String)request.getAttribute("jakarta.servlet.error.request_uri");
 String type = request.getParameter("type");
 StringBuilder redirectPage = new StringBuilder();
-redirectPage.append(((javax.servlet.http.HttpServletRequest)request).getContextPath());
+redirectPage.append(((jakarta.servlet.http.HttpServletRequest)request).getContextPath());
 if("systemError".equals(type)) {
 	if(requestUri != null && !requestUri.endsWith("systemError")) {
 		redirectPage.append("/error/systemerror/");
@@ -17,6 +17,9 @@ if("systemError".equals(type)) {
 	response.sendRedirect(redirectPage.toString());
 } else if("badRequest".equals(type)) {
 	redirectPage.append("/error/badrequest/");
+	response.sendRedirect(redirectPage.toString());
+} else if("busy".equals(type)) {
+	redirectPage.append("/error/busy/");
 	response.sendRedirect(redirectPage.toString());
 } else if(!"badAuth".equals(type)) {
 	redirectPage.append("/error/notfound/?url=");


### PR DESCRIPTION
## Summary

Adds a new busy error page for the simple theme and updates the redirect handler to support the "busy" error type, along with migrating from `javax.servlet` to `jakarta.servlet`.

## Changes Made

- Added `src/main/resources/view/error/busy.jsp`: New error page displayed when the server is busy, following the same structure as other error pages in the theme
- Updated `src/main/resources/view/error/redirect.jsp`:
  - Migrated `javax.servlet.*` attribute lookups to `jakarta.servlet.*` for Jakarta EE compatibility
  - Added redirect handling for the `"busy"` error type, redirecting to `/error/busy/`

## Testing

- Verify the busy error page renders correctly when accessed at `/error/busy/`
- Confirm the redirect from `/error/redirect/?type=busy` navigates to the busy error page
- Ensure existing error redirects (`systemError`, `badRequest`, `badAuth`, `notFound`) still work as expected

## Breaking Changes

- None

## Additional Notes

- The `busy.jsp` follows the same template structure as other error pages, including the shared header, footer, CSS, and JS includes
- The `jakarta.servlet` migration aligns with the broader Jakarta EE transition in Fess