### PR TITLE
chore: bump parent version to 15.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.8.0-SNAPSHOT</version>
+		<version>15.8.0</version>
 		<relativePath />
 	</parent>
 	<build>


### PR DESCRIPTION
Locks onto the released fess-parent 15.8.0.
